### PR TITLE
added exclude domain parameter

### DIFF
--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -13,31 +13,31 @@ class NewsApiClient(object):
                           page=None):
         """
             Returns live top and breaking headlines for a country, specific category in a country, single source, or multiple sources..
-            
+
             Optional parameters:
                 (str) q - return headlines w/ specific keyword or phrase. For example:
                           'bitcoin', 'trump', 'tesla', 'ethereum', etc.
-                            
+
                 (str) sources - return headlines of news sources! some Valid values are:
                                 'bbc-news', 'the-verge', 'abc-news', 'crypto coins news',
                                 'ary news','associated press','wired','aftenposten','australian financial review','axios',
 				'bbc news','bild','blasting news','bloomberg','business insider','engadget','google news',
 				'hacker news','info money,'recode','techcrunch','techradar','the next web','the verge' etc.
-							
+
 		(str) language - The 2-letter ISO-639-1 code of the language you want to get headlines for. Valid values are:
 				 'ar','de','en','es','fr','he','it','nl','no','pt','ru','se','ud','zh'
-                            
+
                 (str) country - The 2-letter ISO 3166-1 code of the country you want to get headlines! Valid values are:
-                                'ae','ar','at','au','be','bg','br','ca','ch','cn','co','cu','cz','de','eg','fr','gb','gr',    									
+                                'ae','ar','at','au','be','bg','br','ca','ch','cn','co','cu','cz','de','eg','fr','gb','gr',
                                 'hk','hu','id','ie','il','in','it','jp','kr','lt','lv','ma','mx','my','ng','nl','no','nz',
                                 'ph','pl','pt','ro','rs','ru','sa','se','sg','si','sk','th','tr','tw','ua','us'
-								
+
 		(str) category - The category you want to get headlines for! Valid values are:
 				 'business','entertainment','general','health','science','sports','technology'
-								
-		(int) page_size - The number of results to return per page (request). 20 is the default, 100 is the maximum. 
-								
-		(int) page - Use this to page through the results if the total results found is greater than the page size.									
+
+		(int) page_size - The number of results to return per page (request). 20 is the default, 100 is the maximum.
+
+		(int) page - Use this to page through the results if the total results found is greater than the page size.
         """
 
         # Define Payload
@@ -50,7 +50,7 @@ class NewsApiClient(object):
             else:
                 raise TypeError('keyword/phrase q param should be a of type str')
 
-        # Sources 
+        # Sources
         if (sources is not None) and ((country is not None) or (category is not None)):
             raise ValueError('cannot mix country/category param with sources param.')
 
@@ -61,7 +61,7 @@ class NewsApiClient(object):
             else:
                 raise TypeError('sources param should be of type str')
 
-        # Language 
+        # Language
         if language is not None:
             if type(language) == str:
                 if language in const.languages:
@@ -120,36 +120,39 @@ class NewsApiClient(object):
 
         return r.json()
 
-    def get_everything(self, q=None, sources=None, domains=None, from_param=None, to=None, language=None,
-                       sort_by=None, page=None, page_size=None):
+    def get_everything(self, q=None, sources=None, domains=None, exclude_domains=None,
+                       from_param=None, to=None, language=None, sort_by=None, page=None,
+                       page_size=None):
         """
             Search through millions of articles from over 5,000 large and small news sources and blogs.
-            
+
             Optional parameters:
                 (str) q - return headlines w/ specified coin! Valid values are:
                             'bitcoin', 'trump', 'tesla', 'ethereum', etc
-                            
+
                 (str) sources - return headlines of news sources! some Valid values are:
                             'bbc-news', 'the-verge', 'abc-news', 'crypto coins news',
                             'ary news','associated press','wired','aftenposten','australian financial review','axios',
 			    'bbc news','bild','blasting news','bloomberg','business insider','engadget','google news',
 		  	    'hacker news','info money,'recode','techcrunch','techradar','the next web','the verge' etc.
-							
-		(str) domains - A comma-seperated string of domains (eg bbc.co.uk, techcrunch.com, engadget.com) to restrict the search to. 
+
+		(str) domains - A comma-seperated string of domains (eg bbc.co.uk, techcrunch.com, engadget.com) to restrict the search to.
+
+        (str) exclude_domains - A comma_seperated string of domains to be excluded from the search
 
 		(str) from_parameter - A date and optional time for the oldest article allowed.
                                        (e.g. 2018-03-05 or 2018-03-05T03:46:15)
-				
+
 		(str) to - A date and optional time for the newest article allowed.
-							
+
 		(str) language - The 2-letter ISO-639-1 code of the language you want to get headlines for. Valid values are:
 				'ar','de','en','es','fr','he','it','nl','no','pt','ru','se','ud','zh'
-								
-		(str) sort_by - The order to sort the articles in. Valid values are: 'relevancy','popularity','publishedAt'
-								
-		(int) page_size - The number of results to return per page (request). 20 is the default, 100 is the maximum.		
 
-		(int) page - Use this to page through the results if the total results found is greater than the page size.									
+		(str) sort_by - The order to sort the articles in. Valid values are: 'relevancy','popularity','publishedAt'
+
+		(int) page_size - The number of results to return per page (request). 20 is the default, 100 is the maximum.
+
+		(int) page - Use this to page through the results if the total results found is greater than the page size.
         """
 
         # Define Payload
@@ -176,7 +179,13 @@ class NewsApiClient(object):
             else:
                 raise TypeError('domains param should be of type str')
 
-        # Search From This Date ... 
+        if exclude_domains is not None:
+            if isinstance(exclude_domains, str):
+                payload['excludeDomains'] = exclude_domains
+            else:
+                raise TypeError('exclude_domains param should be of type str')
+
+        # Search From This Date ...
         if from_param is not None:
             if type(from_param) == str:
                 if (len(from_param)) >= 10:
@@ -190,7 +199,7 @@ class NewsApiClient(object):
             else:
                 raise TypeError('from_param should be of type str')
 
-        # ... To This Date 
+        # ... To This Date
         if to is not None:
             if type(to) == str:
                 if (len(to)) >= 10:
@@ -256,22 +265,22 @@ class NewsApiClient(object):
     def get_sources(self, category=None, language=None, country=None):
         """
             Returns the subset of news publishers that top headlines...
-            
+
             Optional parameters:
                 (str) category - The category you want to get headlines for! Valid values are:
 				 'business','entertainment','general','health','science','sports','technology'
-			
+
 		(str) language - The 2-letter ISO-639-1 code of the language you want to get headlines for. Valid values are:
 				'ar','de','en','es','fr','he','it','nl','no','pt','ru','se','ud','zh'
-                            
+
                 (str) country - The 2-letter ISO 3166-1 code of the country you want to get headlines! Valid values are:
-                                'ae','ar','at','au','be','bg','br','ca','ch','cn','co','cu','cz','de','eg','fr','gb','gr',    									
+                                'ae','ar','at','au','be','bg','br','ca','ch','cn','co','cu','cz','de','eg','fr','gb','gr',
                                 'hk','hu','id','ie','il','in','it','jp','kr','lt','lv','ma','mx','my','ng','nl','no','nz',
                                 'ph','pl','pt','ro','rs','ru','sa','se','sg','si','sk','th','tr','tw','ua','us'
-								
+
 				(str) category - The category you want to get headlines for! Valid values are:
 						'business','entertainment','general','health','science','sports','technology'
-																	
+
         """
 
         # Define Payload

--- a/tests/test_newsapi_client.py
+++ b/tests/test_newsapi_client.py
@@ -97,6 +97,11 @@ class NewsApiClientTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.api.get_everything(domains=domains)
 
+        # Raise TypeError is exclude_domains param is not of type str
+        exclude_domains = 0
+        with self.assertRaises(TypeError):
+            self.api.get_everything(exclude_domains=exclude_domains)
+
         # Raise TypeError is from_param param is not of type str
         from_param = 0
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Hey Matt,

when going through the API docs I noticed that the excludeDomains keyword was missing from the Python API `get_everything` method. I added it in the same form as the other keywords had been added and included testing for the new variable in the same form as you had done for the others. I also added an entry into the docstring.

I just noticed my text editor also got rid of whitespaces in empty lines and at the end of the lines, I hope that's ok too. So the main changes are around lines 180.

Let me know what you think!

Cheers,
Jan