### PR TITLE
Make 'en' default language for get_top_headlines method; issue #18

### DIFF
--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -9,7 +9,7 @@ class NewsApiClient(object):
     def __init__(self, api_key):
         self.auth = NewsApiAuth(api_key=api_key)
 
-    def get_top_headlines(self, q=None, sources=None, language=None, country=None, category=None, page_size=None,
+    def get_top_headlines(self, q=None, sources=None, language='en', country=None, category=None, page_size=None,
                           page=None):
         """
             Returns live top and breaking headlines for a country, specific category in a country, single source, or multiple sources..
@@ -81,7 +81,7 @@ class NewsApiClient(object):
             else:
                 raise TypeError('country param should be of type str')
 
-                # Category
+        # Category
         if category is not None:
             if type(category) == str:
                 if category in const.categories:


### PR DESCRIPTION
Hey Matt,
Great library, thanks for the good work. In reference to open issue #18 I have made the minor fixes to make english the default language.

The only changes are within `get_top_headlines` and a comment formatting fix. All tests are passing, although this is not explicitly tested for. 