### PR TITLE
Added Python 2 unicode support

### DIFF
--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -326,6 +326,7 @@ class NewsApiClient(object):
 
         return r.json()
 
+
 def is_valid_string(var):
     if version_info[0] == 3:
         return isinstance(var, str)

--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -2,6 +2,7 @@ import requests
 from newsapi.newsapi_auth import NewsApiAuth
 from newsapi import const
 from newsapi.newsapi_exception import NewsAPIException
+from sys import version_info
 
 
 class NewsApiClient(object):
@@ -45,10 +46,17 @@ class NewsApiClient(object):
 
         # Keyword/Phrase
         if q is not None:
-            if type(q) == str:
+            if version_info[0] == 3:
+                q_is_str = isinstance(q, str)
+            elif version_info[0] == 2:
+                q_is_str = isinstance(q, basestring)
+            else:
+                raise SystemError("unsupported version of python detected (supported versions: 2, 3)")
+
+            if q_is_str:
                 payload['q'] = q
             else:
-                raise TypeError('keyword/phrase q param should be a of type str')
+                raise TypeError('keyword/phrase q param should be of type str')
 
         # Sources
         if (sources is not None) and ((country is not None) or (category is not None)):
@@ -160,7 +168,14 @@ class NewsApiClient(object):
 
         # Keyword/Phrase
         if q is not None:
-            if type(q) == str:
+            if version_info[0] == 3:
+                q_is_str = isinstance(q, str)
+            elif version_info[0] == 2:
+                q_is_str = isinstance(q, basestring)
+            else:
+                raise SystemError("unsupported version of python detected (supported versions: 2, 3)")
+
+            if q_is_str:
                 payload['q'] = q
             else:
                 raise TypeError('keyword/phrase q param should be of type str')

--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -46,14 +46,7 @@ class NewsApiClient(object):
 
         # Keyword/Phrase
         if q is not None:
-            if version_info[0] == 3:
-                q_is_str = isinstance(q, str)
-            elif version_info[0] == 2:
-                q_is_str = isinstance(q, basestring)
-            else:
-                raise SystemError("unsupported version of python detected (supported versions: 2, 3)")
-
-            if q_is_str:
+            if is_valid_string(q):
                 payload['q'] = q
             else:
                 raise TypeError('keyword/phrase q param should be of type str')
@@ -64,14 +57,14 @@ class NewsApiClient(object):
 
         # Sources
         if sources is not None:
-            if type(sources) == str:
+            if is_valid_string(sources):
                 payload['sources'] = sources
             else:
                 raise TypeError('sources param should be of type str')
 
         # Language
         if language is not None:
-            if type(language) == str:
+            if is_valid_string(language):
                 if language in const.languages:
                     payload['language'] = language
                 else:
@@ -81,7 +74,7 @@ class NewsApiClient(object):
 
         # Country
         if country is not None:
-            if type(country) == str:
+            if is_valid_string(country):
                 if country in const.countries:
                     payload['country'] = country
                 else:
@@ -91,7 +84,7 @@ class NewsApiClient(object):
 
         # Category
         if category is not None:
-            if type(category) == str:
+            if is_valid_string(category):
                 if category in const.categories:
                     payload['category'] = category
                 else:
@@ -168,28 +161,21 @@ class NewsApiClient(object):
 
         # Keyword/Phrase
         if q is not None:
-            if version_info[0] == 3:
-                q_is_str = isinstance(q, str)
-            elif version_info[0] == 2:
-                q_is_str = isinstance(q, basestring)
-            else:
-                raise SystemError("unsupported version of python detected (supported versions: 2, 3)")
-
-            if q_is_str:
+            if is_valid_string(q):
                 payload['q'] = q
             else:
                 raise TypeError('keyword/phrase q param should be of type str')
 
         # Sources
         if sources is not None:
-            if type(sources) == str:
+            if is_valid_string(sources):
                 payload['sources'] = sources
             else:
                 raise TypeError('sources param should be of type str')
 
         # Domains To Search
         if domains is not None:
-            if type(domains) == str:
+            if is_valid_string(domains):
                 payload['domains'] = domains
             else:
                 raise TypeError('domains param should be of type str')
@@ -202,7 +188,7 @@ class NewsApiClient(object):
 
         # Search From This Date ...
         if from_param is not None:
-            if type(from_param) == str:
+            if is_valid_string(from_param):
                 if (len(from_param)) >= 10:
                     for i in range(len(from_param)):
                         if (i == 4 and from_param[i] != '-') or (i == 7 and from_param[i] != '-'):
@@ -216,7 +202,7 @@ class NewsApiClient(object):
 
         # ... To This Date
         if to is not None:
-            if type(to) == str:
+            if is_valid_string(to):
                 if (len(to)) >= 10:
                     for i in range(len(to)):
                         if (i == 4 and to[i] != '-') or (i == 7 and to[i] != '-'):
@@ -230,7 +216,7 @@ class NewsApiClient(object):
 
         # Language
         if language is not None:
-            if type(language) == str:
+            if is_valid_string(language):
                 if language not in const.languages:
                     raise ValueError('invalid language')
                 else:
@@ -240,7 +226,7 @@ class NewsApiClient(object):
 
         # Sort Method
         if sort_by is not None:
-            if type(sort_by) == str:
+            if is_valid_string(sort_by):
                 if sort_by in const.sort_method:
                     payload['sortBy'] = sort_by
                 else:
@@ -303,7 +289,7 @@ class NewsApiClient(object):
 
         # Language
         if language is not None:
-            if type(language) == str:
+            if is_valid_string(language):
                 if language in const.languages:
                     payload['language'] = language
                 else:
@@ -313,7 +299,7 @@ class NewsApiClient(object):
 
         # Country
         if country is not None:
-            if type(country) == str:
+            if is_valid_string(country):
                 if country in const.countries:
                     payload['country'] = country
                 else:
@@ -323,7 +309,7 @@ class NewsApiClient(object):
 
                 # Category
         if category is not None:
-            if type(category) == str:
+            if is_valid_string(category):
                 if category in const.categories:
                     payload['category'] = category
                 else:
@@ -339,3 +325,11 @@ class NewsApiClient(object):
             raise NewsAPIException(r.json())
 
         return r.json()
+
+def is_valid_string(var):
+    if version_info[0] == 3:
+        return isinstance(var, str)
+    elif version_info[0] == 2:
+        return isinstance(var, basestring)
+    else:
+        raise SystemError("unsupported version of python detected (supported versions: 2, 3)")


### PR DESCRIPTION
As per #23, this adds support for unicode query strings in Python 2.x.

Similar support would be easy for other parameters (source, country, etc.) if necessary. That may necessitate making a helper function for the conversion, though, since it'd be a fair bit of code.

Tested on Python 2.7.16