### PR TITLE
Update const.languages to use correct ISO-639-1 codes

### DIFF
--- a/newsapi/const.py
+++ b/newsapi/const.py
@@ -6,7 +6,7 @@ countries = {'ae','ar','at','au','be','bg','br','ca','ch','cn','co','cu','cz','d
              'hu','id','ie','il','in','it','jp','kr','lt','lv','ma','mx','my','ng','nl','no','nz','ph','pl',
              'pt','ro','rs','ru','sa','se','sg','si','sk','th','tr','tw','ua','us','ve','za'}
 
-languages = {'ar','en','cn','de','es','fr','he','it','nl','no','pt','ru','sv','ud'}
+languages = {'ar','de','en','es','fr','he','it','nl','no','pt','ru','se','ud','zh'}
 
 categories = {'business', 'entertainment', 'general', 'health', 'science', 'sports', 'technology'}
 


### PR DESCRIPTION
"zh" and "se" are the correct codes, per https://newsapi.org/docs/endpoints/everything.