### PR TITLE
Accept additional type inputs for to & from_param

### DIFF
--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -1,6 +1,7 @@
 import requests
 from newsapi.newsapi_auth import NewsApiAuth
 from newsapi import const
+from newsapi import utils
 from newsapi.newsapi_exception import NewsAPIException
 from sys import version_info
 
@@ -145,10 +146,12 @@ class NewsApiClient(object):
 
         (str) exclude_domains - A comma_seperated string of domains to be excluded from the search
 
-		(str) from_param - A date and optional time for the oldest article allowed.
-                                       (e.g. 2018-03-05 or 2018-03-05T03:46:15)
+		(str, date, datetime, float, int, or None)
+        from_param - A date and optional time for the oldest article allowed.
+                     (e.g. 2018-03-05 or 2018-03-05T03:46:15)
 
-		(str) to - A date and optional time for the newest article allowed.
+		(str, date, datetime, float, int, or None)
+        to - A date and optional time for the newest article allowed.
 
 		(str) language - The 2-letter ISO-639-1 code of the language you want to get headlines for. Valid values are:
 				'ar','de','en','es','fr','he','it','nl','no','pt','ru','se','ud','zh'
@@ -192,31 +195,11 @@ class NewsApiClient(object):
 
         # Search From This Date ...
         if from_param is not None:
-            if is_valid_string(from_param):
-                if (len(from_param)) >= 10:
-                    for i in range(len(from_param)):
-                        if (i == 4 and from_param[i] != '-') or (i == 7 and from_param[i] != '-'):
-                            raise ValueError('from_param should be in the format of YYYY-MM-DD')
-                        else:
-                            payload['from'] = from_param
-                else:
-                    raise ValueError('from_param should be in the format of YYYY-MM-DD')
-            else:
-                raise TypeError('from_param should be of type str')
+            payload['from'] = utils.stringify_date_param(from_param)
 
         # ... To This Date
         if to is not None:
-            if is_valid_string(to):
-                if (len(to)) >= 10:
-                    for i in range(len(to)):
-                        if (i == 4 and to[i] != '-') or (i == 7 and to[i] != '-'):
-                            raise ValueError('to should be in the format of YYYY-MM-DD')
-                        else:
-                            payload['to'] = to
-                else:
-                    raise ValueError('to param should be in the format of YYYY-MM-DD')
-            else:
-                raise TypeError('to param should be of type str')
+            payload['to'] = utils.stringify_date_param(to)
 
         # Language
         if language is not None:

--- a/newsapi/utils.py
+++ b/newsapi/utils.py
@@ -1,0 +1,81 @@
+from __future__ import unicode_literals
+
+__all__ = ("stringify_date_param",)
+
+import datetime
+import re
+import sys
+
+# Date in ISO-8601 format
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+DATE_LEN = len("YYYY-MM-DD")
+DATE_FMT = "%Y-%m-%d"
+
+# Datetime in ISO-8601 format
+DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")
+DATETIME_LEN = len("YYYY-MM-DDTHH:MM:SS")
+DATETIME_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+def stringify_date_param(dt):
+    if is_valid_string(dt):
+        if len(dt) == DATE_LEN:
+            validate_date_str(dt)
+        elif len(dt) == DATETIME_LEN:
+            validate_datetime_str(dt)
+        else:
+            raise ValueError(
+                "Date input should be in format of either YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"
+            )
+        return dt
+    # Careful: datetime.datetime is subclass of datetime.date!
+    elif isinstance(dt, datetime.datetime):
+        # TODO: time zone
+        return dt.strftime(DATETIME_FMT)
+    elif isinstance(dt, datetime.date):
+        return dt.strftime(DATE_FMT)
+    elif is_valid_num(dt):
+        return datetime.datetime.utcfromtimestamp(dt).strftime(DATETIME_FMT)
+    else:
+        raise TypeError(
+            "Date input must be one of: str, date, datetime, float, int, or None"
+        )
+
+
+def validate_date_str(datestr):
+    if not DATE_RE.match(datestr):
+        raise ValueError("Date input should be in format of YYYY-MM-DD")
+
+
+def validate_datetime_str(datetimestr):
+    if not DATETIME_RE.match(datetimestr):
+        raise ValueError("Datetime input should be in format of YYYY-MM-DDTHH:MM:SS")
+
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+
+    def is_valid_string(var):
+        return isinstance(var, str)
+
+    def is_valid_num(var):
+        return isinstance(var, (int, float))
+
+
+elif PY2:
+
+    def is_valid_string(var):
+        return isinstance(var, basestring)
+
+    def is_valid_num(var):
+        return isinstance(var, (int, float, long))
+
+
+else:
+
+    def is_valid_string(var):
+        raise SystemError(
+            "unsupported version of python detected (supported versions: 2, 3)"
+        )

--- a/tests/test_newsapi_client.py
+++ b/tests/test_newsapi_client.py
@@ -102,26 +102,6 @@ class NewsApiClientTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.api.get_everything(exclude_domains=exclude_domains)
 
-        # Raise TypeError is from_param param is not of type str
-        from_param = 0
-        with self.assertRaises(TypeError):
-            self.api.get_everything(from_param=from_param)
-
-        # Raise ValueError if param is not in the format YYYY-MM-DD
-        from_param = '2016-6-4'
-        with self.assertRaises(ValueError):
-            self.api.get_everything(from_param=from_param)
-
-        # Raise TypeError if to param is not of type str
-        to = 1
-        with self.assertRaises(TypeError):
-            self.api.get_everything(to=to)
-
-        # Raise ValueError if to param is not in the format YYYY-MM-DD
-        to = '2016-6-24'
-        with self.assertRaises(ValueError):
-            self.api.get_everything(to=to)
-
         # Raise TypeError if language param is not of type str
         language = 0
         with self.assertRaises(TypeError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,72 @@
+import datetime
+import time
+import unittest
+
+from newsapi import utils
+
+
+class StringifyDateParamTest(unittest.TestCase):
+    """Test utils.stringify_date_param()."""
+
+    def test_str_input(self):
+        for inp in (
+            "2019-01-01",
+            "2019-01-01T00:00:00",
+            "2019-12-30T00:00:00",
+            "2019-12-30T04:05:06",
+            "2019-09-06T16:17:48",
+        ):
+            if utils.PY3:
+                with self.subTest(inp=inp):
+                    self.assertEqual(inp, utils.stringify_date_param(inp))
+            else:
+                self.assertEqual(inp, utils.stringify_date_param(inp))
+
+    def test_date_input(self):
+        self.assertEqual(
+            "2019-01-01", utils.stringify_date_param(datetime.date(2019, 1, 1))
+        )
+        self.assertEqual(
+            "2019-12-30", utils.stringify_date_param(datetime.date(2019, 12, 30))
+        )
+
+    def test_datetime_input(self):
+        self.assertEqual(
+            "2019-01-01T00:00:00",
+            utils.stringify_date_param(datetime.datetime(2019, 1, 1)),
+        )
+        self.assertEqual(
+            "2019-12-30T00:00:00",
+            utils.stringify_date_param(datetime.datetime(2019, 12, 30)),
+        )
+        self.assertEqual(
+            "2019-12-30T04:05:06",
+            utils.stringify_date_param(datetime.datetime(2019, 12, 30, 4, 5, 6)),
+        )
+
+    def test_unix_ts_input(self):
+        self.assertEqual(
+            "2019-09-06T16:17:48", utils.stringify_date_param(1567786668.826787)
+        )
+        self.assertEqual("2019-09-06T16:17:48", utils.stringify_date_param(1567786668))
+
+    def test_malformed_str_input(self):
+        for bad_input in (
+            "20190101",
+            "01-01-2019",
+            "2019-01-01 00:00:00",
+            "2019-01-01T00:00:00-04:00",
+        ):
+            if utils.PY3:
+                with self.subTest(bad_input=bad_input):
+                    with self.assertRaises(ValueError):
+                        utils.stringify_date_param(bad_input)
+            else:
+                with self.assertRaises(ValueError):
+                    utils.stringify_date_param(bad_input)
+
+    def test_incorrect_type_input(self):
+        with self.assertRaises(TypeError):
+            utils.stringify_date_param(None)
+        with self.assertRaises(TypeError):
+            utils.stringify_date_param([datetime.date(2019, 12, 30)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import time
 import unittest
 
 from newsapi import utils


### PR DESCRIPTION
Accept date, datetime, float, int, str, or None for both date-related parameters.

The input will be converted to either an ISO-8601 date string or datetime string using `utils.stringify_date_param()`.

A couple possible TODOs (at least to document):
- This assumes the datetime input is UTC (whether it is naive or tz-aware).
- This does not do additional validation of date as `str` (i.e. validating that month is in 1..12.