### PR TITLE
Added a default languages dict const.py to resolve (Issue #78)

### DIFF
--- a/newsapi/const.py
+++ b/newsapi/const.py
@@ -1,12 +1,11 @@
 """Constants and allowed parameter values specified in the News API."""
-
 TOP_HEADLINES_URL = "https://newsapi.org/v2/top-headlines"
 EVERYTHING_URL = "https://newsapi.org/v2/everything"
 SOURCES_URL = "https://newsapi.org/v2/sources"
 
 #: The 2-letter ISO 3166-1 code of the country you want to get headlines for.  If not specified,
 #: the results span all countries.
-countries = {
+COUNTRIES = {
     "ae",
     "ar",
     "at",
@@ -22,7 +21,6 @@ countries = {
     "cz",
     "de",
     "eg",
-    "es",
     "fr",
     "gb",
     "gr",
@@ -32,7 +30,6 @@ countries = {
     "ie",
     "il",
     "in",
-    "is",
     "it",
     "jp",
     "kr",
@@ -46,7 +43,6 @@ countries = {
     "no",
     "nz",
     "ph",
-    "pk",
     "pl",
     "pt",
     "ro",
@@ -64,17 +60,73 @@ countries = {
     "us",
     "ve",
     "za",
-    "zh",
+}
+
+DEFAULT_LANGUAGES = {
+    "ae": "ar",
+    "ar": "es",
+    "at": "de",
+    "au": "en",
+    "be": "nl",
+    "bg": "bg",
+    "br": "pt",
+    "ca": "en",
+    "ch": "de",
+    "cn": "zh",
+    "co": "es",
+    "cu": "es",
+    "cz": "cs",
+    "de": "de",
+    "eg": "ar",
+    "fr": "fr",
+    "gb": "en",
+    "gr": "el",
+    "hk": "zh",
+    "hu": "hu",
+    "id": "id",
+    "ie": "en",
+    "il": "he",
+    "in": "hi",
+    "it": "it",
+    "jp": "ja",
+    "kr": "ko",
+    "lt": "lt",
+    "lv": "lv",
+    "ma": "ar",
+    "mx": "es",
+    "my": "ms",
+    "ng": "en",
+    "nl": "nl",
+    "no": "no",
+    "nz": "en",
+    "ph": "en",
+    "pl": "pl",
+    "pt": "pt",
+    "ro": "ro",
+    "rs": "sr",
+    "ru": "ru",
+    "sa": "ar",
+    "se": "sv",
+    "sg": "en",
+    "si": "sl",
+    "sk": "sk",
+    "th": "th",
+    "tr": "tr",
+    "tw": "zh",
+    "ua": "uk",
+    "us": "en",
+    "ve": "es",
+    "za": "zu",
 }
 
 #: The 2-letter ISO-639-1 code of the language you want to get articles for.  If not specified,
 #: the results span all languages.
-languages = {"ar", "en", "cn", "de", "es", "fr", "he", "it", "nl", "no", "pt", "ru", "sv", "se", "ud", "zh",
-             "en-US"}
+LANGUAGES = {"ar", "de", "en", "es", "fr", "he", "it", "nl", "no", "pt", "ru", "sv", "ud", "zh"}
 
 #: The category you want to get articles for.  If not specified,
 #: the results span all categories.
-categories = {"business", "entertainment", "general", "health", "science", "sports", "technology"}
+CATEGORIES = {"business", "entertainment", "general", "health", "science", "sports", "technology"}
 
 #: The order to sort article results in.  If not specified, the default is ``"publishedAt"``.
-sort_method = {"relevancy", "popularity", "publishedAt"}
+SORT_METHOD = {"relevancy", "popularity", "publishedAt"}
+

--- a/newsapi/newsapi_client.py
+++ b/newsapi/newsapi_client.py
@@ -32,7 +32,7 @@ class NewsApiClient(object):
             self.request_method = session
 
     def get_top_headlines(  # noqa: C901
-        self, q=None, qintitle=None, sources=None, language="en", country=None, category=None, page_size=None, page=None
+        self, q=None, qintitle=None, sources=None, language=None, country=None, category=None, page_size=None, page=None
     ):
         """Call the `/top-headlines` endpoint.
 
@@ -116,17 +116,18 @@ class NewsApiClient(object):
         # Language
         if language is not None:
             if is_valid_string(language):
-                if language in const.languages:
+                if language in const.LANGUAGES:
                     payload["language"] = language
                 else:
                     raise ValueError("invalid language")
             else:
                 raise TypeError("language param should be of type str")
 
+
         # Country
         if country is not None:
             if is_valid_string(country):
-                if country in const.countries:
+                if country in const.COUNTRIES:
                     payload["country"] = country
                 else:
                     raise ValueError("invalid country")
@@ -136,7 +137,7 @@ class NewsApiClient(object):
         # Category
         if category is not None:
             if is_valid_string(category):
-                if category in const.categories:
+                if category in const.CATEGORIES:
                     payload["category"] = category
                 else:
                     raise ValueError("invalid category")
@@ -162,7 +163,8 @@ class NewsApiClient(object):
                     raise ValueError("page param should be an int greater than 0")
             else:
                 raise TypeError("page param should be an int")
-
+        if payload.get("language") is None:
+            payload["language"] = const.DEFAULT_LANGUAGES.get(country)
         # Send Request
         r = self.request_method.get(const.TOP_HEADLINES_URL, auth=self.auth, timeout=30, params=payload)
 
@@ -291,7 +293,7 @@ class NewsApiClient(object):
         # Language
         if language is not None:
             if is_valid_string(language):
-                if language not in const.languages:
+                if language not in const.LANGUAGES:
                     raise ValueError("invalid language")
                 else:
                     payload["language"] = language
@@ -301,7 +303,7 @@ class NewsApiClient(object):
         # Sort Method
         if sort_by is not None:
             if is_valid_string(sort_by):
-                if sort_by in const.sort_method:
+                if sort_by in const.SORT_METHOD:
                     payload["sortBy"] = sort_by
                 else:
                     raise ValueError("invalid sort")
@@ -330,7 +332,7 @@ class NewsApiClient(object):
 
         # Send Request
         r = self.request_method.get(const.EVERYTHING_URL, auth=self.auth, timeout=30, params=payload)
-
+        
         # Check Status of Request
         if r.status_code != requests.codes.ok:
             raise NewsAPIException(r.json())
@@ -364,7 +366,7 @@ class NewsApiClient(object):
         # Language
         if language is not None:
             if is_valid_string(language):
-                if language in const.languages:
+                if language in const.LANGUAGES:
                     payload["language"] = language
                 else:
                     raise ValueError("invalid language")
@@ -374,7 +376,7 @@ class NewsApiClient(object):
         # Country
         if country is not None:
             if is_valid_string(country):
-                if country in const.countries:
+                if country in const.COUNTRIES:
                     payload["country"] = country
                 else:
                     raise ValueError("invalid country")
@@ -384,7 +386,7 @@ class NewsApiClient(object):
         # Category
         if category is not None:
             if is_valid_string(category):
-                if category in const.categories:
+                if category in const.CATEGORIES:
                     payload["category"] = category
                 else:
                     raise ValueError("invalid category")
@@ -392,6 +394,8 @@ class NewsApiClient(object):
                 raise TypeError("category param should be of type str")
 
         # Send Request
+        if payload.get("language") is None:
+            payload["language"] = const.DEFAULT_LANGUAGES.get(country)
         r = self.request_method.get(const.SOURCES_URL, auth=self.auth, timeout=30, params=payload)
 
         # Check Status of Request


### PR DESCRIPTION
- Updated languages and countries to use the correct set of 2-letter ISO 3166-1 and ISO-639-1 codes listed on NewsAPI Documentation.

- Update const.py to include a DEFAULT_LANGUAGES dictionary for mapping ISO 3166-1 to their respective official/most-used language ISO-639-1 code. This resolves the "se" language issue while minimizing results provided by NewsAPI's default: all languages.

- Update newsapi_client.py to set payload["language"] to it's countries default language.